### PR TITLE
Fix protocol consolidation error on tests

### DIFF
--- a/lib/mizur.ex
+++ b/lib/mizur.ex
@@ -11,7 +11,7 @@ defmodule Mizur do
   defmacro __using__(_opts) do 
     quote do 
       use Mizur.System
-      #use Mizur.Implementation
+      use Mizur.Implementation
       use Mizur.Api
       use Mizur.Range
     end

--- a/lib/mizur/implementation.ex
+++ b/lib/mizur/implementation.ex
@@ -1,17 +1,14 @@
-defmodule Mizur.Implementation do 
+defmodule Mizur.Implementation do
 
   @moduledoc false
 
-  defmacro __using__(_opts) do 
-    quote do 
-
-      defimpl String.Chars, for: __MODULE__.Type do 
-        def to_string(element) do 
-          "test"
+  defmacro __using__(_opts) do
+    quote do
+      defimpl String.Chars, for: __MODULE__ do
+        def to_string(element) do
+          to_string(element.value) <> to_string(element.type.name)
         end
       end
-
     end
   end
-
 end

--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,8 @@ defmodule Mizur.Mixfile do
       ],
       package: package(),
       description: description(),
-      deps: deps()
+      deps: deps(),
+      consolidate_protocols: Mix.env != :test
     ]
   end
 

--- a/test/mizur_test.exs
+++ b/test/mizur_test.exs
@@ -453,6 +453,8 @@ defmodule MizurTest do
     assert li == range
   end
 
-  
-  
+  test "String.Chars protocol implementation" do
+    l = Length.cm(10)
+    assert "10.0cm" == to_string(l)
+  end
 end


### PR DESCRIPTION
Protocol consolidation needs to be turned off when we implement
protocols in the test files.

It's because the consolidation occurs when the project is compiled. The
tests are compiled later (when they need to be run) so the consolidation
is no longer possible.

Anyway, here I just turned the consolidation off for the test environment.

More information here: https://github.com/elixir-lang/elixir/issues/4175